### PR TITLE
[codex] Add telemetry protocol, simulation, and dashboard pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,56 @@
 # CANOBD2Reader
+
+ESP32-basierter CAN-/OBD2-Reader mit ESP-NOW-Telemetrie und separater LilyGo-T-Display-S3-Anzeige.
+
+## Sketches
+
+- `ino/CAN_OBD2_Gateway.ino`: Reader/Sender für CAN, OBD2-Abfragen, Batteriespannung und ESP-NOW-Telemetrie.
+- `ino/Anzeige_LilyGoTDisplayS3.ino`: Anzeige/Empfänger mit mehreren Dashboard-Seiten.
+
+## Telemetrie-Protokoll
+
+Textpakete werden als CRC-geschützter ESP-NOW-Frame übertragen:
+
+```text
+TYPE,KEY,NAME,VALUE,UNIT,STATUS,SEQ
+```
+
+Beispiele:
+
+```text
+OBD,0C,RPM,1850.00,rpm,OK,42
+OBD,05,CoolantTemp,89.00,°C,OK,43
+BATTERY,VOLTAGE,BatteryVoltage,12.64,V,OK,44
+STATUS,CAN,CAN,ACTIVE,,OK,45
+```
+
+Die Anzeige markiert fehlende oder veraltete Werte nach Timeout als `--`.
+
+Zusätzlich fragt der Sender unterstützte PID-Bereiche ab und überspringt nicht unterstützte Live-Daten-PIDs. Fehlercodes werden über OBD Mode `0x03` gelesen und als `DTC`-Paket übertragen.
+
+## Display-Seiten
+
+1. Hauptanzeige: Geschwindigkeit, Drehzahl, Kühlmitteltemperatur, Batteriespannung
+2. Motorwerte: Öltemperatur, Kühlmitteltemperatur, Motorlast, Ansauglufttemperatur
+3. Verbrauch: Durchschnittsverbrauch, Kraftstoffrate, Geschwindigkeit, Drosselklappe
+4. Zusatzwerte: MAF, Tankfüllstand, Motorlaufzeit, Umgebungstemperatur
+5. CAN-Rohdaten: letzter CAN-Frame, Frame-Zähler, einfache OBD/CAN-Hinweise
+6. Diagnose: ESP-NOW, CAN/OBD, Datenqualität, CRC-/Drop-Zähler
+7. Fehlercodes: DTC-Status und aktive Fehlercodes
+
+## Simulation
+
+Für Kommunikationstests ohne Fahrzeug kann im Sender `ENABLE_TELEMETRY_SIMULATION` auf `1` gesetzt werden. Dann initialisiert der Sender nur ESP-NOW und sendet simulierte Werte für alle Display-Seiten.
+
+Für reine Displaytests ohne Sender kann im Display `ENABLE_DISPLAY_INTERNAL_SIMULATION` auf `1` gesetzt werden. Der normale Testpfad sollte aber der Sender-Simulationsmodus sein, weil damit ESP-NOW, CRC, Paketformat und Anzeige gemeinsam geprüft werden.
+
+Gemeinsame Logik liegt in:
+
+- `include/TelemetryProtocol.h`
+- `include/SimulationData.h`
+- `include/CANDecoder.h`
+- `src/CANDecoder.cpp`
+
+## OTA-Hinweis
+
+`platformio.ini` nutzt `board_build.partitions = min_spiffs.csv`. Dieses Layout bleibt OTA-kompatibel für typische 4-MB-ESP32-Boards, weil zwei App-Partitionen erhalten bleiben. Änderungen an der Partitionstabelle sollten nur erfolgen, wenn die Flash-Größe des Zielboards bekannt ist.

--- a/docs/TELEMETRY_PROTOCOL.md
+++ b/docs/TELEMETRY_PROTOCOL.md
@@ -1,0 +1,51 @@
+# Telemetry Protocol
+
+Sender and display use the same ESP-NOW text frame:
+
+```cpp
+typedef struct {
+  char payload[128];
+  uint16_t crc;
+} esp_now_text_frame_t;
+```
+
+The CRC is calculated over the struct excluding the final `crc` field.
+
+Payload format:
+
+```text
+TYPE,KEY,NAME,VALUE,UNIT,STATUS,SEQ
+```
+
+Fields:
+
+- `TYPE`: `OBD`, `BATTERY`, `FUEL`, `DTC`, or `STATUS`
+- `KEY`: PID hex value or logical key
+- `NAME`: stable display name
+- `VALUE`: numeric value or `N/A`
+- `UNIT`: physical unit, empty for pure status values
+- `STATUS`: `OK`, `WARN`, `ALERT`, `TIMEOUT`, `SEND_FAIL`, or `ERROR`
+- `SEQ`: sender-side packet counter for packet-loss estimation
+
+Current display pages consume these names:
+
+- Main: `Speed`, `RPM`, `CoolantTemp`, `BatteryVoltage`
+- Engine: `OilTemp`, `CoolantTemp`, `EngineLoad`, `IntakeTemp`
+- Consumption: `AverageConsumption`, `FuelRate`, `Speed`, `Throttle`
+- Additional values: `MAF`, `FuelLevel`, `RunTime`, `AmbientTemp`
+- CAN page: `LastCAN`, `CANHint`, `CANCount`
+- Diagnostics: `CAN`, packet counters, CRC errors, last payload
+- Error codes: `DTC`
+
+The sender periodically queries supported PID ranges (`0x00`, `0x20`, `0x40`) and skips unsupported live-data PIDs after support detection. DTCs are queried with OBD mode `0x03` and sent as a space-separated code list.
+
+Simulation:
+
+- Sender flag: `ENABLE_TELEMETRY_SIMULATION`
+- Display-only flag: `ENABLE_DISPLAY_INTERNAL_SIMULATION`
+- Shared simulated values: `include/SimulationData.h`
+
+Backward compatibility:
+
+- Old battery packets like `BATTERY,VOLTAGE,12.4,V` are still accepted.
+- Old three-field OBD packets like `0C,RPM,1800 rpm` are still accepted, but provide less status information.

--- a/include/CANDecoder.h
+++ b/include/CANDecoder.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <Arduino.h>
+#include <driver/twai.h>
+
+namespace CANDecoder {
+
+struct DecodedFrame {
+    char raw[64]{};
+    char hint[48]{};
+};
+
+// Erstellt eine kompakte Textdarstellung fuer die Anzeige. Ohne fahrzeugspezifische
+// DBC-Datei werden Roh-ID, DLC und Bytes angezeigt; bekannte OBD-Antworten werden
+// als Hinweis markiert.
+DecodedFrame decode(const twai_message_t& message);
+
+} // namespace CANDecoder

--- a/include/CANHandler.h
+++ b/include/CANHandler.h
@@ -13,6 +13,8 @@ public:
     static void processIncoming();
 
     /// @brief Behandelt eingehende CAN-Nachricht
+    /// Neben dem binaeren Rohframe wird eine lesbare CAN-Zusammenfassung fuer
+    /// die Display-CAN-Seite erzeugt.
     static void handleMessage(twai_message_t& message);
 
     /// @brief Prüft und druckt den aktuellen Status (optional)

--- a/include/Config.h
+++ b/include/Config.h
@@ -39,15 +39,29 @@ namespace Config {
     constexpr int SleepPeriodSec = 6;
     constexpr bool sendRawDataOnly = false;
     constexpr uint32_t ObdIntervalMs = 200;
+    constexpr uint32_t SupportedPidRefreshIntervalMs = 60000;
+    constexpr uint32_t DtcQueryIntervalMs = 30000;
+    // Schaltet einen reinen ESP-NOW-Kommunikationstest frei. In diesem Modus
+    // koennen Sender und Display ohne Fahrzeug/CAN-Transceiver getestet werden.
+    constexpr bool EnableTelemetrySimulation = false;
+    constexpr uint32_t SimulationIntervalMs = 250;
     //constexpr const char* TWAI_OPERATION_MODE = "TWAI_MODE_LISTEN";
     constexpr twai_mode_t TWAI_OPERATION_MODE = TWAI_MODE_NORMAL;
 
     // ----------- OBD2 PIDs ----------
     inline constexpr byte ObdRequestedPids[] = {
         ENGINE_RPM,
+        ENGINE_LOAD,
         ENGINE_COOLANT_TEMP,
-        ENGINE_OIL_TEMP,
         VEHICLE_SPEED,
+        INTAKE_AIR_TEMP,
+        MAF_FLOW_RATE,
+        THROTTLE_POSITION,
+        FUEL_TANK_LEVEL_INPUT,
+        RUN_TIME_SINCE_ENGINE_START,
+        CONTROL_MODULE_VOLTAGE,
+        AMBIENT_AIR_TEMP,
+        ENGINE_OIL_TEMP,
         ENGINE_FUEL_RATE
     };
 

--- a/include/OBDHandler.h
+++ b/include/OBDHandler.h
@@ -13,6 +13,9 @@ public:
     static bool receiveResponse(uint8_t mode, uint8_t pid, uint8_t* outData, uint8_t& outLen);
 
     /// @brief Fordert PID an und sendet Ergebnis via Utils
+    /// Alle erfolgreichen Werte werden im gemeinsamen Telemetrieformat gesendet.
+    /// Werte, die fuer abgeleitete Berechnungen gebraucht werden, werden nicht
+    /// mehr unterdrueckt, damit das Display vollstaendig synchron bleibt.
     static void requestAndSendPID(uint8_t pid);
 
     /// @brief Berechnet und sendet Verbrauch aus Speed + FuelRate

--- a/include/SimulationData.h
+++ b/include/SimulationData.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <Arduino.h>
+
+namespace SimulationData {
+
+struct Sample {
+    const char* type;
+    const char* key;
+    const char* name;
+    const char* unit;
+    float minValue;
+    float maxValue;
+    uint8_t decimals;
+};
+
+// Werte fuer alle Display-Seiten. Die Simulation laeuft deterministisch als
+// langsam schwingende Rampe, damit Verbindungs- und Timeoutverhalten testbar ist.
+inline constexpr Sample Samples[] = {
+    {"OBD", "0D", "Speed", "km/h", 0.0f, 130.0f, 0},
+    {"OBD", "0C", "RPM", "rpm", 750.0f, 4200.0f, 0},
+    {"OBD", "05", "CoolantTemp", "°C", 75.0f, 104.0f, 0},
+    {"BATTERY", "VOLTAGE", "BatteryVoltage", "V", 12.2f, 14.4f, 1},
+    {"OBD", "5C", "OilTemp", "°C", 70.0f, 118.0f, 0},
+    {"OBD", "04", "EngineLoad", "%", 12.0f, 92.0f, 0},
+    {"OBD", "0F", "IntakeTemp", "°C", 18.0f, 55.0f, 0},
+    {"FUEL", "AVG", "AverageConsumption", "L/100km", 5.5f, 12.8f, 1},
+    {"OBD", "5E", "FuelRate", "L/h", 0.4f, 24.0f, 1},
+    {"OBD", "11", "Throttle", "%", 0.0f, 88.0f, 0},
+    {"OBD", "10", "MAF", "g/s", 2.0f, 95.0f, 1},
+    {"OBD", "2F", "FuelLevel", "%", 18.0f, 84.0f, 0},
+    {"OBD", "1F", "RunTime", "s", 0.0f, 3600.0f, 0},
+    {"OBD", "46", "AmbientTemp", "°C", -5.0f, 36.0f, 0},
+};
+
+inline constexpr size_t SampleCount = sizeof(Samples) / sizeof(Samples[0]);
+
+inline float valueForSample(const Sample& sample, uint32_t millisNow, size_t index) {
+    const float phase = ((millisNow / 250U) + static_cast<uint32_t>(index * 17U)) % 200U;
+    const float triangle = phase < 100.0f ? phase / 100.0f : (200.0f - phase) / 100.0f;
+    return sample.minValue + (sample.maxValue - sample.minValue) * triangle;
+}
+
+} // namespace SimulationData

--- a/include/TelemetryProtocol.h
+++ b/include/TelemetryProtocol.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <Arduino.h>
+
+namespace TelemetryProtocol {
+
+constexpr size_t MaxPayloadLength = 128;
+constexpr uint8_t Version = 2;
+
+// Gemeinsamer ESP-NOW-Textframe fuer Sender und Anzeige.
+// Der CRC wird ueber den kompletten Frame ohne das letzte crc-Feld berechnet.
+struct TextFrame {
+    char payload[MaxPayloadLength]{};
+    uint16_t crc = 0;
+};
+
+inline uint16_t crc16(const uint8_t* data, size_t length) {
+    uint16_t crc = 0xFFFF;
+    for (size_t i = 0; i < length; ++i) {
+        crc ^= data[i];
+        for (int bit = 0; bit < 8; ++bit) {
+            crc = (crc & 1) ? (crc >> 1) ^ 0xA001 : crc >> 1;
+        }
+    }
+    return crc;
+}
+
+inline void finalizeFrame(TextFrame& frame) {
+    frame.payload[MaxPayloadLength - 1] = '\0';
+    frame.crc = crc16(reinterpret_cast<const uint8_t*>(&frame), sizeof(TextFrame) - sizeof(frame.crc));
+}
+
+inline bool validateFrame(const TextFrame& frame) {
+    return crc16(reinterpret_cast<const uint8_t*>(&frame), sizeof(TextFrame) - sizeof(frame.crc)) == frame.crc;
+}
+
+inline void buildPayload(char* out,
+                         size_t outSize,
+                         const char* type,
+                         const char* key,
+                         const char* name,
+                         const char* value,
+                         const char* unit,
+                         const char* status,
+                         uint32_t sequence) {
+    snprintf(out, outSize, "%s,%s,%s,%s,%s,%s,%lu",
+             type, key, name, value, unit, status,
+             static_cast<unsigned long>(sequence));
+}
+
+} // namespace TelemetryProtocol

--- a/include/Utils.h
+++ b/include/Utils.h
@@ -2,22 +2,13 @@
 #include <Arduino.h>
 #include <esp_now.h>
 #include "Config.h"
+#include "TelemetryProtocol.h"
 
 namespace Utils {
 
     // ============ CRC ============
     inline uint16_t crc16(const uint8_t* data, size_t length) {
-        uint16_t crc = 0xFFFF;
-        for (size_t i = 0; i < length; ++i) {
-            crc ^= data[i];
-            for (int j = 0; j < 8; ++j) {
-                if (crc & 1)
-                    crc = (crc >> 1) ^ 0xA001;
-                else
-                    crc >>= 1;
-            }
-        }
-        return crc;
+        return TelemetryProtocol::crc16(data, length);
     }
 
     // ============ ESP-NOW SEND ============
@@ -28,9 +19,22 @@ namespace Utils {
 
         strncpy(textFrame.payload, payload, sizeof(textFrame.payload));
         textFrame.payload[sizeof(textFrame.payload)-1] = '\0';
-        textFrame.crc = crc16(reinterpret_cast<uint8_t*>(&textFrame), sizeof(textFrame) - 2);
+        textFrame.crc = TelemetryProtocol::crc16(reinterpret_cast<uint8_t*>(&textFrame), sizeof(textFrame) - 2);
 
         esp_now_send(EspNowPeerMac, reinterpret_cast<uint8_t*>(&textFrame), sizeof(textFrame));
+    }
+
+    inline void sendTelemetry(const char* type,
+                              const char* key,
+                              const char* name,
+                              const char* value,
+                              const char* unit,
+                              const char* status) {
+        static uint32_t sequence = 0;
+        char payload[TelemetryProtocol::MaxPayloadLength];
+        TelemetryProtocol::buildPayload(payload, sizeof(payload),
+                                        type, key, name, value, unit, status, ++sequence);
+        sendTextFrame(payload);
     }
 
     /// @brief Sendet CAN-Datenframe über ESP-NOW
@@ -62,16 +66,18 @@ namespace Utils {
 
     /// @brief Sendet ein OBD2-Ergebnis (berechneter Wert + Einheit)
     inline void sendOBDValue(byte pid, const char* name, float value, const char* unit) {
-        char buffer[64];
-        snprintf(buffer, sizeof(buffer), "%02X,%s,%.2f,%s", pid, name, value, unit);
-        sendTextFrame(buffer);
+        char pidHex[4];
+        char valueText[16];
+        snprintf(pidHex, sizeof(pidHex), "%02X", pid);
+        snprintf(valueText, sizeof(valueText), "%.2f", value);
+        sendTelemetry("OBD", pidHex, name, valueText, unit, "OK");
     }
 
     /// @brief Sendet ein OBD2-Fehlerframe
     inline void sendOBDError(byte pid, const char* name) {
-        char buffer[64];
-        snprintf(buffer, sizeof(buffer), "%02X,%s,ERROR,N/A", pid, name);
-        sendTextFrame(buffer);
+        char pidHex[4];
+        snprintf(pidHex, sizeof(pidHex), "%02X", pid);
+        sendTelemetry("OBD", pidHex, name, "N/A", "", "TIMEOUT");
     }
 
 }

--- a/ino/Anzeige_LilyGoTDisplayS3.ino
+++ b/ino/Anzeige_LilyGoTDisplayS3.ino
@@ -3,63 +3,109 @@
 #include <esp_now.h>
 #include <WiFi.h>
 #include "driver/ledc.h"
-#include <cmath>
 #include <SPI.h>
+#if __has_include("TelemetryProtocol.h")
+  #include "TelemetryProtocol.h"
+#else
+  #include "../include/TelemetryProtocol.h"
+#endif
+#if __has_include("SimulationData.h")
+  #include "SimulationData.h"
+#else
+  #include "../include/SimulationData.h"
+#endif
+
+// Anzeige / Empfänger für LilyGo T-Display S3
+// Erwartetes Telemetrieformat vom Sender:
+// TYPE,KEY,NAME,VALUE,UNIT,STATUS,SEQ
+
+#define DISPLAY_FIRMWARE_VERSION "3.1204"
+#define TELEMETRY_PROTOCOL_VERSION 2
 
 #define DISPLAY_ROTATION 1
-#define BACKLIGHT_PIN    38
-
-const float RPM_MIN = 0.0;
-const float RPM_MAX = 6000.0;
-const float RPM_GREEN_MAX = 3000.0;
-const float RPM_ORANGE_MAX = 4500.0;
-const float RPM_WARNING_THRESHOLD = 4200.0;
-
-const uint8_t BACKLIGHT_ON = 255;
-const int BAR_HEIGHT = 12;
-const int BAR_MARGIN_X = 10;
-const int BAR_OFFSET_Y = 25;
-const float rpmSmoothing = 0.2; // schnelleres Reagieren
-const int screenUpdateDelay = 30;
-
-bool darkMode = true;
-uint16_t textColorDark = TFT_WHITE;
-uint16_t bgColorDark = TFT_BLACK;
-uint16_t textColorLight = TFT_BLACK;
-uint16_t bgColorLight = TFT_WHITE;
+#define BACKLIGHT_PIN 38
+#define NEXT_PAGE_BUTTON_PIN 0
 
 #define MAX_PAYLOAD_LEN 128
 #define USE_ESPNOW_ENCRYPTION true
+#define ENABLE_DISPLAY_INTERNAL_SIMULATION 0  // 1 = Display ohne Sender mit lokalen Testdaten fuellen
+
+const uint32_t SCREEN_REFRESH_MS = 250;
+const uint32_t CONNECTION_TIMEOUT_MS = 3000;
+const uint32_t VALUE_TIMEOUT_MS = 5000;
+const uint32_t BUTTON_DEBOUNCE_MS = 250;
+
+const uint8_t BACKLIGHT_ON = 255;
+const uint8_t PAGE_COUNT = 7;
+
+const uint16_t COLOR_BACKGROUND = TFT_BLACK;
+const uint16_t COLOR_PANEL = 0x18E3;       // dunkles Grau/Blau
+const uint16_t COLOR_TEXT = TFT_WHITE;
+const uint16_t COLOR_MUTED = TFT_DARKGREY;
+const uint16_t COLOR_ACCENT = TFT_CYAN;
+const uint16_t COLOR_OK = TFT_GREEN;
+const uint16_t COLOR_WARN = TFT_ORANGE;
+const uint16_t COLOR_ERROR = TFT_RED;
+
+typedef TelemetryProtocol::TextFrame esp_now_text_frame_t;
 
 typedef struct {
-  char payload[MAX_PAYLOAD_LEN];
+  uint8_t magic = 0x42;
+  uint32_t timestamp;
+  int mesh_id;
+  unsigned long can_id;
+  byte len;
+  uint8_t d[8];
   uint16_t crc;
-} esp_now_text_frame_t;
+} esp_now_can_frame_t;
+
+struct TelemetryValue {
+  String type;
+  String key;
+  String name;
+  String value;
+  String unit;
+  String status;
+  uint32_t sequence = 0;
+  uint32_t updatedAt = 0;
+};
 
 const uint8_t allowed_sender_mac[6] = { 0x8C, 0x4B, 0x14, 0x27, 0xEB, 0x48 };
-const uint8_t lmk[16] = { 0x3A, 0x7F, 0xC2, 0x91, 0x18, 0x5D, 0xE0, 0xB3, 0x4C, 0x22, 0xA1, 0x6E, 0xD4, 0x0F, 0x97, 0x8B };
+const uint8_t lmk[16] = {
+  0x3A, 0x7F, 0xC2, 0x91, 0x18, 0x5D, 0xE0, 0xB3,
+  0x4C, 0x22, 0xA1, 0x6E, 0xD4, 0x0F, 0x97, 0x8B
+};
+
+TFT_eSPI tft = TFT_eSPI();
+
+TelemetryValue values[28];
+uint8_t valueCount = 0;
+uint8_t currentPage = 0;
+uint8_t lastRenderedPage = 255;
+uint32_t lastScreenRefresh = 0;
+uint32_t lastReceivedAt = 0;
+uint32_t lastButtonAt = 0;
+uint32_t receivedPackets = 0;
+uint32_t droppedPackets = 0;
+uint32_t crcErrors = 0;
+uint32_t lastSequence = 0;
+String lastRawPayload = "";
+String lastError = "Keine Daten";
+uint32_t lastInternalSimulationUpdate = 0;
+size_t internalSimulationIndex = 0;
+
+void onDataRecv(const esp_now_recv_info_t *info, const uint8_t *incomingData, int len);
 
 uint16_t crc16(const uint8_t* data, size_t length) {
   uint16_t crc = 0xFFFF;
   for (size_t i = 0; i < length; ++i) {
     crc ^= data[i];
-    for (int j = 0; j < 8; ++j)
+    for (int j = 0; j < 8; ++j) {
       crc = (crc & 1) ? (crc >> 1) ^ 0xA001 : crc >> 1;
+    }
   }
   return crc;
 }
-
-TFT_eSPI tft = TFT_eSPI();
-
-String header1 = "", header2 = "", rpmValue = "", rpmUnit = "";
-String lastPID = "";
-float currentRPM = 0, targetRPM = 0;
-float voltageLast = 0.0;
-int lastBarWidth = -1;
-unsigned long lastReceivedTime = 0;
-unsigned long lastVoltageUpdate = 0;
-bool simulationActive = false;
-unsigned long simStartTime = 0;
 
 void setBacklight(uint8_t brightness) {
   ledc_set_duty(LEDC_LOW_SPEED_MODE, LEDC_CHANNEL_0, brightness);
@@ -67,148 +113,457 @@ void setBacklight(uint8_t brightness) {
 }
 
 void setupBacklight() {
-  ledc_timer_config_t ledc_timer = { LEDC_LOW_SPEED_MODE, LEDC_TIMER_8_BIT, LEDC_TIMER_0, 10000, LEDC_AUTO_CLK };
-  ledc_timer_config(&ledc_timer);
-  ledc_channel_config_t ledc_channel = { BACKLIGHT_PIN, LEDC_LOW_SPEED_MODE, LEDC_CHANNEL_0, LEDC_INTR_DISABLE, LEDC_TIMER_0, 0, 0 };
-  ledc_channel_config(&ledc_channel);
+  ledc_timer_config_t timer = {};
+  timer.speed_mode = LEDC_LOW_SPEED_MODE;
+  timer.duty_resolution = LEDC_TIMER_8_BIT;
+  timer.timer_num = LEDC_TIMER_0;
+  timer.freq_hz = 10000;
+  timer.clk_cfg = LEDC_AUTO_CLK;
+  ledc_timer_config(&timer);
+
+  ledc_channel_config_t channel = {};
+  channel.gpio_num = BACKLIGHT_PIN;
+  channel.speed_mode = LEDC_LOW_SPEED_MODE;
+  channel.channel = LEDC_CHANNEL_0;
+  channel.intr_type = LEDC_INTR_DISABLE;
+  channel.timer_sel = LEDC_TIMER_0;
+  channel.duty = 0;
+  ledc_channel_config(&channel);
+
   setBacklight(BACKLIGHT_ON);
 }
 
 void setupESPNow() {
   WiFi.mode(WIFI_STA);
-  if (esp_now_init() != ESP_OK) return;
+  WiFi.disconnect();
+
+  if (esp_now_init() != ESP_OK) {
+    lastError = "ESP-NOW Init fehlgeschlagen";
+    return;
+  }
 
   esp_now_peer_info_t peer = {};
   memcpy(peer.peer_addr, allowed_sender_mac, 6);
   peer.channel = 1;
   peer.encrypt = USE_ESPNOW_ENCRYPTION;
   if (USE_ESPNOW_ENCRYPTION) memcpy(peer.lmk, lmk, 16);
-  esp_now_add_peer(&peer);
+
+  esp_err_t peerResult = esp_now_add_peer(&peer);
+  if (peerResult != ESP_OK && peerResult != ESP_ERR_ESPNOW_EXIST) {
+    lastError = "ESP-NOW Peer fehlgeschlagen";
+    return;
+  }
+
   esp_now_register_recv_cb(onDataRecv);
+  lastError = "Warte auf Sender";
 }
 
-void showBootAnimation() {
-  tft.fillScreen(TFT_BLACK);
+TelemetryValue* findValue(const String& name) {
+  for (uint8_t i = 0; i < valueCount; i++) {
+    if (values[i].name == name || values[i].key == name) return &values[i];
+  }
+  return nullptr;
+}
+
+TelemetryValue* upsertValue(const String& type,
+                            const String& key,
+                            const String& name,
+                            const String& value,
+                            const String& unit,
+                            const String& status,
+                            uint32_t sequence) {
+  TelemetryValue* existing = findValue(name);
+  if (existing == nullptr) existing = findValue(key);
+
+  if (existing == nullptr) {
+    if (valueCount >= (sizeof(values) / sizeof(values[0]))) {
+      droppedPackets++;
+      lastError = "Werteliste voll";
+      return nullptr;
+    }
+    existing = &values[valueCount++];
+  }
+
+  existing->type = type;
+  existing->key = key;
+  existing->name = name;
+  existing->value = value;
+  existing->unit = unit;
+  existing->status = status;
+  existing->sequence = sequence;
+  existing->updatedAt = millis();
+  return existing;
+}
+
+String fieldAt(const String& raw, uint8_t index) {
+  int start = 0;
+  for (uint8_t i = 0; i < index; i++) {
+    start = raw.indexOf(',', start);
+    if (start < 0) return "";
+    start++;
+  }
+  int end = raw.indexOf(',', start);
+  if (end < 0) end = raw.length();
+  return raw.substring(start, end);
+}
+
+uint8_t countFields(const String& raw) {
+  uint8_t fields = raw.length() > 0 ? 1 : 0;
+  for (uint16_t i = 0; i < raw.length(); i++) {
+    if (raw[i] == ',') fields++;
+  }
+  return fields;
+}
+
+void parseTelemetryPayload(const String& raw) {
+  const uint8_t fields = countFields(raw);
+  if (fields < 3) {
+    droppedPackets++;
+    lastError = "Ungültiges Paket";
+    return;
+  }
+
+  String type = fieldAt(raw, 0);
+  String key = fieldAt(raw, 1);
+  String name = fieldAt(raw, 2);
+  String value = fields > 3 ? fieldAt(raw, 3) : "";
+  String unit = fields > 4 ? fieldAt(raw, 4) : "";
+  String status = fields > 5 ? fieldAt(raw, 5) : "OK";
+  uint32_t sequence = fields > 6 ? fieldAt(raw, 6).toInt() : 0;
+
+  // Rückwärtskompatibilität für alte Pakete BATTERY,VOLTAGE,12.3,V.
+  if (type == "BATTERY" && key == "VOLTAGE" && fields == 4) {
+    name = "BatteryVoltage";
+    value = fieldAt(raw, 2);
+    unit = fieldAt(raw, 3);
+    status = "OK";
+  }
+
+  // Rückwärtskompatibilität für alte Pakete PID,Name,Wert Einheit.
+  if (fields == 3) {
+    type = "OBD";
+    key = fieldAt(raw, 0);
+    name = fieldAt(raw, 1);
+    value = fieldAt(raw, 2);
+    unit = "";
+    status = value == "N/A" ? "TIMEOUT" : "OK";
+  }
+
+  if (sequence > 0 && lastSequence > 0 && sequence > lastSequence + 1) {
+    droppedPackets += sequence - lastSequence - 1;
+  }
+  if (sequence > 0) lastSequence = sequence;
+
+  upsertValue(type, key, name, value, unit, status, sequence);
+  lastRawPayload = raw;
+  lastError = status == "OK" ? "" : status;
+}
+
+void onDataRecv(const esp_now_recv_info_t *info, const uint8_t *incomingData, int len) {
+  if (memcmp(info->src_addr, allowed_sender_mac, 6) != 0) {
+    droppedPackets++;
+    return;
+  }
+
+  if (len == sizeof(esp_now_can_frame_t)) {
+    esp_now_can_frame_t canFrame;
+    memcpy(&canFrame, incomingData, sizeof(canFrame));
+    if (TelemetryProtocol::crc16((uint8_t*)&canFrame, sizeof(canFrame) - 2) != canFrame.crc) {
+      crcErrors++;
+      lastError = "CAN CRC-Fehler";
+      return;
+    }
+
+    char raw[64];
+    size_t offset = snprintf(raw, sizeof(raw), "0x%03lX DLC%u",
+                             static_cast<unsigned long>(canFrame.can_id),
+                             static_cast<unsigned int>(canFrame.len));
+    for (uint8_t i = 0; i < canFrame.len && i < 8 && offset < sizeof(raw); i++) {
+      offset += snprintf(raw + offset, sizeof(raw) - offset, " %02X", canFrame.d[i]);
+    }
+
+    receivedPackets++;
+    lastReceivedAt = millis();
+    upsertValue("CAN", "RAW", "LastCAN", raw, "", "OK", receivedPackets);
+    upsertValue("CAN", "COUNT", "CANCount", String(receivedPackets).c_str(), "frames", "OK", receivedPackets);
+    upsertValue("CAN", "HINT", "CANHint", "CAN Rohdaten", "", "OK", receivedPackets);
+    return;
+  }
+
+  if (len != sizeof(esp_now_text_frame_t)) {
+    droppedPackets++;
+    return;
+  }
+
+  esp_now_text_frame_t frame;
+  memcpy(&frame, incomingData, sizeof(frame));
+  if (!TelemetryProtocol::validateFrame(frame)) {
+    crcErrors++;
+    lastError = "CRC-Fehler";
+    return;
+  }
+
+  frame.payload[MAX_PAYLOAD_LEN - 1] = '\0';
+  receivedPackets++;
+  lastReceivedAt = millis();
+  parseTelemetryPayload(String(frame.payload));
+}
+
+bool isConnected() {
+  return lastReceivedAt > 0 && millis() - lastReceivedAt <= CONNECTION_TIMEOUT_MS;
+}
+
+bool isFresh(const TelemetryValue* value) {
+  if (value == nullptr || millis() - value->updatedAt > VALUE_TIMEOUT_MS) return false;
+  return value->status == "OK" || value->status == "WARN" || value->status == "ALERT";
+}
+
+String displayValue(const char* name, uint8_t decimals = 0) {
+  TelemetryValue* value = findValue(String(name));
+  if (!isFresh(value)) return "--";
+
+  if (value->value == "N/A" || value->value.length() == 0) return "--";
+  float numericValue = value->value.toFloat();
+  String result = String(numericValue, decimals);
+  if (value->unit.length() > 0) result += " " + value->unit;
+  return result;
+}
+
+String displayText(const char* name) {
+  TelemetryValue* value = findValue(String(name));
+  if (value == nullptr || millis() - value->updatedAt > VALUE_TIMEOUT_MS) return "--";
+  if (value->value.length() == 0 || value->value == "N/A") return "--";
+  return value->value;
+}
+
+uint16_t valueColor(const char* name) {
+  TelemetryValue* value = findValue(String(name));
+  if (!isFresh(value)) return COLOR_MUTED;
+
+  float numericValue = value->value.toFloat();
+  String n = String(name);
+  if (n == "CoolantTemp" && numericValue >= 105.0f) return COLOR_ERROR;
+  if (n == "OilTemp" && numericValue >= 125.0f) return COLOR_ERROR;
+  if (n == "BatteryVoltage" && (numericValue < 11.5f || numericValue > 14.8f)) return COLOR_WARN;
+  if (n == "RPM" && numericValue >= 4200.0f) return COLOR_WARN;
+  return COLOR_TEXT;
+}
+
+void drawStatusBar() {
+  const uint16_t barColor = isConnected() ? COLOR_PANEL : COLOR_ERROR;
+  tft.fillRect(0, 0, tft.width(), 20, barColor);
+  tft.setTextSize(1);
+  tft.setTextDatum(ML_DATUM);
+  tft.setTextColor(COLOR_TEXT, barColor);
+  tft.drawString(isConnected() ? "ESP-NOW OK" : "VERBINDUNG VERLOREN", 4, 10);
+
+  tft.setTextDatum(MR_DATUM);
+  String right = "S" + String(currentPage + 1) + "/" + String(PAGE_COUNT);
+  if (lastReceivedAt > 0) right += "  " + String((millis() - lastReceivedAt) / 1000) + "s";
+  tft.drawString(right, tft.width() - 4, 10);
+}
+
+void drawFooter() {
+  tft.fillRect(0, tft.height() - 16, tft.width(), 16, COLOR_BACKGROUND);
+  tft.setTextSize(1);
+  tft.setTextDatum(ML_DATUM);
+  tft.setTextColor(COLOR_MUTED, COLOR_BACKGROUND);
+  String footer = "FW ";
+  footer += DISPLAY_FIRMWARE_VERSION;
+  footer += "  Proto ";
+  footer += String(TELEMETRY_PROTOCOL_VERSION);
+  tft.drawString(footer, 4, tft.height() - 8);
+}
+
+void drawMetricBox(int x, int y, int w, int h, const char* label, const String& value, uint16_t color) {
+  tft.fillRoundRect(x, y, w, h, 6, COLOR_PANEL);
+  tft.setTextDatum(TL_DATUM);
+  tft.setTextSize(1);
+  tft.setTextColor(COLOR_MUTED, COLOR_PANEL);
+  tft.drawString(label, x + 8, y + 6);
+
   tft.setTextDatum(MC_DATUM);
-  tft.setTextSize(4);
-  tft.setTextColor(TFT_WHITE, TFT_BLACK);
-  tft.drawString("R-Line", tft.width() / 2, tft.height() / 2);
-  delay(1000);
-  tft.fillScreen(TFT_BLACK);
+  tft.setTextSize(value.length() > 8 ? 2 : 3);
+  tft.setTextColor(color, COLOR_PANEL);
+  tft.drawString(value, x + w / 2, y + h / 2 + 8);
+}
+
+void drawMainPage() {
+  drawMetricBox(6, 28, 150, 58, "Geschwindigkeit", displayValue("Speed", 0), valueColor("Speed"));
+  drawMetricBox(164, 28, 150, 58, "Drehzahl", displayValue("RPM", 0), valueColor("RPM"));
+  drawMetricBox(6, 94, 150, 58, "Kühlmittel", displayValue("CoolantTemp", 0), valueColor("CoolantTemp"));
+  drawMetricBox(164, 94, 150, 58, "Bordspannung", displayValue("BatteryVoltage", 1), valueColor("BatteryVoltage"));
+}
+
+void drawEnginePage() {
+  drawMetricBox(6, 28, 150, 58, "Öltemperatur", displayValue("OilTemp", 0), valueColor("OilTemp"));
+  drawMetricBox(164, 28, 150, 58, "Kühlmittel", displayValue("CoolantTemp", 0), valueColor("CoolantTemp"));
+  drawMetricBox(6, 94, 150, 58, "Motorlast", displayValue("EngineLoad", 0), valueColor("EngineLoad"));
+  drawMetricBox(164, 94, 150, 58, "Ansaugluft", displayValue("IntakeTemp", 0), valueColor("IntakeTemp"));
+}
+
+void drawConsumptionPage() {
+  drawMetricBox(6, 28, 150, 58, "Ø Verbrauch", displayValue("AverageConsumption", 1), valueColor("AverageConsumption"));
+  drawMetricBox(164, 28, 150, 58, "Kraftstoffrate", displayValue("FuelRate", 1), valueColor("FuelRate"));
+  drawMetricBox(6, 94, 150, 58, "Geschwindigkeit", displayValue("Speed", 0), valueColor("Speed"));
+  drawMetricBox(164, 94, 150, 58, "Drosselklappe", displayValue("Throttle", 0), valueColor("Throttle"));
+}
+
+void drawAdditionalPage() {
+  drawMetricBox(6, 28, 150, 58, "MAF", displayValue("MAF", 1), valueColor("MAF"));
+  drawMetricBox(164, 28, 150, 58, "Tankfüllstand", displayValue("FuelLevel", 0), valueColor("FuelLevel"));
+  drawMetricBox(6, 94, 150, 58, "Motorlaufzeit", displayValue("RunTime", 0), valueColor("RunTime"));
+  drawMetricBox(164, 94, 150, 58, "Außentemp.", displayValue("AmbientTemp", 0), valueColor("AmbientTemp"));
+}
+
+void drawDiagnosticsPage() {
+  uint32_t totalPackets = receivedPackets + droppedPackets;
+  uint8_t quality = totalPackets == 0 ? 0 : (receivedPackets * 100UL) / totalPackets;
+  TelemetryValue* canStatus = findValue("CAN");
+
+  drawMetricBox(6, 28, 150, 42, "ESP-NOW", isConnected() ? "aktiv" : "verloren", isConnected() ? COLOR_OK : COLOR_ERROR);
+  bool canStatusRecent = canStatus != nullptr && millis() - canStatus->updatedAt <= VALUE_TIMEOUT_MS;
+  drawMetricBox(164, 28, 150, 42, "CAN/OBD", canStatusRecent ? canStatus->value : "--", isFresh(canStatus) ? COLOR_OK : COLOR_WARN);
+  drawMetricBox(6, 76, 150, 42, "Datenqualität", String(quality) + " %", quality > 90 ? COLOR_OK : COLOR_WARN);
+  drawMetricBox(164, 76, 150, 42, "CRC/Drop", String(crcErrors) + "/" + String(droppedPackets), (crcErrors == 0 && droppedPackets == 0) ? COLOR_OK : COLOR_WARN);
+
+  tft.fillRoundRect(6, 124, 308, 28, 6, COLOR_PANEL);
+  tft.setTextDatum(ML_DATUM);
+  tft.setTextSize(1);
+  tft.setTextColor(COLOR_MUTED, COLOR_PANEL);
+  tft.drawString("Letztes Paket:", 14, 132);
+  tft.setTextColor(COLOR_TEXT, COLOR_PANEL);
+  String raw = lastRawPayload.length() > 42 ? lastRawPayload.substring(0, 42) + "..." : lastRawPayload;
+  tft.drawString(raw.length() ? raw : lastError, 14, 144);
+}
+
+void drawCANPage() {
+  drawMetricBox(6, 28, 150, 42, "CAN Frames", displayValue("CANCount", 0), valueColor("CANCount"));
+  drawMetricBox(164, 28, 150, 42, "CAN Status", displayText("CAN"), isConnected() ? COLOR_OK : COLOR_WARN);
+
+  tft.fillRoundRect(6, 78, 308, 74, 6, COLOR_PANEL);
+  tft.setTextDatum(TL_DATUM);
+  tft.setTextSize(1);
+  tft.setTextColor(COLOR_MUTED, COLOR_PANEL);
+  tft.drawString("Letzter CAN-Frame:", 14, 86);
+  tft.setTextColor(COLOR_TEXT, COLOR_PANEL);
+  String raw = displayText("LastCAN");
+  if (raw.length() > 42) raw = raw.substring(0, 42) + "...";
+  tft.drawString(raw, 14, 102);
+
+  tft.setTextColor(COLOR_MUTED, COLOR_PANEL);
+  tft.drawString("Auswertung:", 14, 126);
+  tft.setTextColor(COLOR_ACCENT, COLOR_PANEL);
+  String hint = displayText("CANHint");
+  if (hint.length() > 36) hint = hint.substring(0, 36) + "...";
+  tft.drawString(hint, 14, 140);
+}
+
+void drawDTCPage() {
+  TelemetryValue* dtc = findValue("DTC");
+  const bool dtcFresh = dtc != nullptr && millis() - dtc->updatedAt <= VALUE_TIMEOUT_MS;
+  const bool hasFault = dtcFresh && dtc->status == "WARN" && dtc->value != "Keine";
+
+  drawMetricBox(6, 28, 308, 48, "Fehlercodes / DTC", dtcFresh ? (hasFault ? "AKTIV" : "Keine") : "--",
+                hasFault ? COLOR_WARN : (dtcFresh ? COLOR_OK : COLOR_MUTED));
+
+  tft.fillRoundRect(6, 88, 308, 64, 6, COLOR_PANEL);
+  tft.setTextDatum(TL_DATUM);
+  tft.setTextSize(1);
+  tft.setTextColor(COLOR_MUTED, COLOR_PANEL);
+  tft.drawString("Codes:", 14, 96);
+
+  tft.setTextSize(2);
+  tft.setTextColor(hasFault ? COLOR_WARN : COLOR_TEXT, COLOR_PANEL);
+  String codes = displayText("DTC");
+  if (codes.length() > 24) codes = codes.substring(0, 24);
+  tft.drawString(codes, 14, 116);
+
+  tft.setTextSize(1);
+  tft.setTextColor(COLOR_MUTED, COLOR_PANEL);
+  String age = dtcFresh ? "Letzte DTC-Abfrage: " + String((millis() - dtc->updatedAt) / 1000) + "s" : "Keine aktuelle DTC-Abfrage";
+  tft.drawString(age, 14, 142);
+}
+
+void updateInternalSimulation() {
+  if (!ENABLE_DISPLAY_INTERNAL_SIMULATION) return;
+  if (millis() - lastInternalSimulationUpdate < 120) return;
+  lastInternalSimulationUpdate = millis();
+
+  const SimulationData::Sample& sample =
+      SimulationData::Samples[internalSimulationIndex % SimulationData::SampleCount];
+
+  char value[16];
+  const float simulatedValue = SimulationData::valueForSample(sample, millis(), internalSimulationIndex);
+  snprintf(value, sizeof(value), sample.decimals == 0 ? "%.0f" : "%.1f", simulatedValue);
+  upsertValue(sample.type, sample.key, sample.name, value, sample.unit, "OK", internalSimulationIndex + 1);
+
+  internalSimulationIndex++;
+  lastReceivedAt = millis();
+  if (internalSimulationIndex % SimulationData::SampleCount == 0) {
+    upsertValue("STATUS", "CAN", "CAN", "SIMULATED", "", "OK", internalSimulationIndex);
+    upsertValue("CAN", "RAW", "LastCAN", "0x7E8 DLC8 04 41 0C 1A F8 55 55 55", "", "OK", internalSimulationIndex);
+    upsertValue("CAN", "HINT", "CANHint", "Lokale CAN-Simulation", "", "OK", internalSimulationIndex);
+    upsertValue("CAN", "COUNT", "CANCount", "128", "frames", "OK", internalSimulationIndex);
+    upsertValue("DTC", "ACTIVE", "DTC", "P0133 P0420", "", "WARN", internalSimulationIndex);
+  }
+}
+
+void renderCurrentPage() {
+  tft.fillScreen(COLOR_BACKGROUND);
+  drawStatusBar();
+
+  switch (currentPage) {
+    case 0: drawMainPage(); break;
+    case 1: drawEnginePage(); break;
+    case 2: drawConsumptionPage(); break;
+    case 3: drawAdditionalPage(); break;
+    case 4: drawCANPage(); break;
+    case 5: drawDiagnosticsPage(); break;
+    case 6: drawDTCPage(); break;
+  }
+
+  drawFooter();
+}
+
+void handleButton() {
+  if (digitalRead(NEXT_PAGE_BUTTON_PIN) == LOW && millis() - lastButtonAt > BUTTON_DEBOUNCE_MS) {
+    currentPage = (currentPage + 1) % PAGE_COUNT;
+    lastRenderedPage = 255;
+    lastButtonAt = millis();
+  }
+}
+
+void showBootScreen() {
+  tft.fillScreen(COLOR_BACKGROUND);
+  tft.setTextDatum(MC_DATUM);
+  tft.setTextSize(3);
+  tft.setTextColor(COLOR_ACCENT, COLOR_BACKGROUND);
+  tft.drawString("CAN OBD2", tft.width() / 2, tft.height() / 2 - 12);
+  tft.setTextSize(1);
+  tft.setTextColor(COLOR_MUTED, COLOR_BACKGROUND);
+  tft.drawString("Display " DISPLAY_FIRMWARE_VERSION, tft.width() / 2, tft.height() / 2 + 22);
+  delay(900);
 }
 
 void setup() {
   Serial.begin(115200);
+  pinMode(NEXT_PAGE_BUTTON_PIN, INPUT_PULLUP);
+
   tft.init();
   tft.setRotation(DISPLAY_ROTATION);
-  showBootAnimation();
-  tft.fillScreen(darkMode ? bgColorDark : bgColorLight);
-  tft.setTextColor(darkMode ? textColorDark : textColorLight);
   setupBacklight();
+  showBootScreen();
   setupESPNow();
-  simStartTime = millis();
-}
-
-void onDataRecv(const esp_now_recv_info_t *info, const uint8_t *incomingData, int len) {
-  if (memcmp(info->src_addr, allowed_sender_mac, 6) != 0 || len != sizeof(esp_now_text_frame_t)) return;
-
-  esp_now_text_frame_t frame;
-  memcpy(&frame, incomingData, sizeof(frame));
-  if (crc16((uint8_t*)&frame, sizeof(frame) - 2) != frame.crc) return;
-
-  String raw = String(frame.payload);
-  Serial.println("Empfangen: " + raw);
-
-  int c1 = raw.indexOf(','), c2 = raw.indexOf(',', c1 + 1), c3 = raw.indexOf(',', c2 + 1);
-  if (c1 <= 0 || c2 <= c1 || c3 <= c2) return;
-
-  header1 = raw.substring(0, c1);
-  header2 = raw.substring(c1 + 1, c2);
-  rpmValue = raw.substring(c2 + 1, c3);
-  rpmUnit  = raw.substring(c3 + 1);
-
-  if (header1 == "BATTERY" && header2 == "VOLTAGE") {
-    voltageLast = rpmValue.toFloat();
-    lastVoltageUpdate = millis();
-  } else {
-    if (rpmValue != "ERROR") {
-      targetRPM = rpmValue.toFloat();
-      simulationActive = false;
-    }
-    lastPID = header2; // z. B. PID
-  }
-
-  lastReceivedTime = millis(); // immer setzen
-}
-
-uint16_t getRPMColor(float rpm) {
-  float clamped = constrain(rpm, RPM_MIN, RPM_MAX);
-  if (clamped <= RPM_GREEN_MAX) return TFT_GREEN;
-  if (clamped <= RPM_ORANGE_MAX) return TFT_ORANGE;
-  return TFT_RED;
 }
 
 void loop() {
-  if (simulationActive) {
-    float simulated = 3000.0 + 2700.0 * sin((millis() - simStartTime) / 1000.0);
-    targetRPM = constrain(simulated, RPM_MIN, RPM_MAX);
-    voltageLast = 13.4;
-    lastVoltageUpdate = millis();
+  updateInternalSimulation();
+  handleButton();
+
+  if (millis() - lastScreenRefresh >= SCREEN_REFRESH_MS || lastRenderedPage != currentPage) {
+    renderCurrentPage();
+    lastRenderedPage = currentPage;
+    lastScreenRefresh = millis();
   }
-
-  currentRPM = std::lerp(currentRPM, targetRPM, rpmSmoothing);
-  float clampedRPM = constrain(currentRPM, RPM_MIN, RPM_MAX);
-  uint16_t currentBGColor = darkMode ? bgColorDark : bgColorLight;
-
-  // RPM Anzeige
-  tft.setTextDatum(MC_DATUM);
-  tft.setTextSize(3);
-  String rpmStr = String(clampedRPM, 0) + " " + rpmUnit;
-  int x = tft.width() / 2;
-  int y = tft.height() / 2;
-  int w = tft.textWidth("0000 rpm", 3);
-  int h = 3 * 8 + 4;
-  tft.fillRect(x - w / 2, y - h / 2, w, h, currentBGColor);
-  tft.setTextColor(TFT_WHITE, currentBGColor);
-  tft.drawString(rpmStr, x, y);
-
-  // Fortschrittsbalken
-  int barWidth = map(clampedRPM, RPM_MIN, RPM_MAX, 0, tft.width() - 2 * BAR_MARGIN_X);
-  if (barWidth != lastBarWidth) {
-    lastBarWidth = barWidth;
-    int barX = BAR_MARGIN_X;
-    int barY = y + BAR_OFFSET_Y;
-    tft.fillRect(barX, barY, tft.width() - 2 * BAR_MARGIN_X, BAR_HEIGHT, currentBGColor);
-    tft.drawRect(barX - 1, barY - 1, tft.width() - 2 * BAR_MARGIN_X + 2, BAR_HEIGHT + 2, TFT_WHITE);
-    tft.fillRect(barX, barY, barWidth, BAR_HEIGHT, getRPMColor(clampedRPM));
-  }
-
-  // Spannung oben rechts
-  if (millis() - lastVoltageUpdate < 10000 && voltageLast > 0.0) {
-    tft.setTextDatum(TR_DATUM);
-    tft.setTextSize(2);
-    tft.setTextColor(TFT_CYAN, currentBGColor);
-    String vstr = String(voltageLast, 2) + " V";
-    tft.fillRect(tft.width() - 80, 0, 80, 20, currentBGColor);
-    tft.drawString(vstr, tft.width() - 5, 2);
-  }
-
-  // Keine Verbindung nur bei echter Funkstille
-  if (!simulationActive && millis() - lastReceivedTime > 3000) {
-    tft.fillRect(0, 0, tft.width(), 40, currentBGColor);
-    tft.setTextDatum(TC_DATUM);
-    tft.setTextSize(2);
-    tft.setTextColor(TFT_RED, currentBGColor);
-    tft.drawString("Keine Verbindung", tft.width() / 2, 10);
-    tft.drawString("Warte auf Daten...", tft.width() / 2, 30);
-  }
-
-  // PID oder Fehler unten rechts anzeigen
-  tft.setTextDatum(BR_DATUM);
-  tft.setTextSize(1);
-  tft.setTextColor(TFT_DARKGREY, currentBGColor);
-  tft.fillRect(tft.width() - 100, tft.height() - 12, 100, 12, currentBGColor);
-  tft.drawString("PID: " + lastPID, tft.width() - 2, tft.height() - 2);
-
-  delay(screenUpdateDelay);
 }

--- a/ino/CAN_OBD2_Gateway.ino
+++ b/ino/CAN_OBD2_Gateway.ino
@@ -15,14 +15,39 @@
 #include <Arduino.h>
 #include <esp_now.h>
 #include <WiFi.h>
+#include <string.h>
 #include "driver/twai.h"
-#include "PIDs.h"
-#include "PID_Converter.h"
+#if __has_include("PIDs.h")
+  #include "PIDs.h"
+#else
+  #include "../include/PIDs.h"
+#endif
+#if __has_include("PID_Converter.h")
+  #include "PID_Converter.h"
+#else
+  #include "../include/PID_Converter.h"
+#endif
+#if __has_include("TelemetryProtocol.h")
+  #include "TelemetryProtocol.h"
+#else
+  #include "../include/TelemetryProtocol.h"
+#endif
+#if __has_include("SimulationData.h")
+  #include "SimulationData.h"
+#else
+  #include "../include/SimulationData.h"
+#endif
+#if __has_include("CANDecoder.h")
+  #include "CANDecoder.h"
+#else
+  #include "../include/CANDecoder.h"
+#endif
 // End region ================================== Includes ==================================
 
 // region ================================== #define ==================================
-// --------- Firmeware ---------
-#define FIRMWARE_VER "3.1203"
+// --------- Firmware ---------
+#define FIRMWARE_VERSION "3.1204"
+#define TELEMETRY_PROTOCOL_VERSION 2
 // -----------------------------
 
 // ------ Debug Optionen -------
@@ -78,10 +103,17 @@
 #define SHIELD_VOLTAGE_DIVIDER 32
 
 // ------------ CAN / OBD2 ------------
-#define POLLING_RATE_MS 500
-#define CAN_IDLE_TIMEOUT 500
+#define POLLING_RATE_MS 250
+#define CAN_IDLE_TIMEOUT_MS 1500
+#define OBD_RESPONSE_TIMEOUT_MS 250
+#define OBD_TX_TIMEOUT_MS 50
+#define BATTERY_SEND_INTERVAL_MS 3000
+#define SUPPORTED_PID_REFRESH_INTERVAL_MS 60000
+#define DTC_QUERY_INTERVAL_MS 30000
 #define SLEEP_PERIOD 6 // 6
 #define RAW_DATA_ONLY 0  // 1 = nur Rohdaten senden, 0 = berechnete Werte senden
+#define ENABLE_TELEMETRY_SIMULATION 0  // 1 = ohne echten CAN/OBD-Bus simulierte Daten senden
+#define SIMULATION_SEND_INTERVAL_MS 250
 
 // ----------- Fahrzeug Status -----------
 #define CAR_IS_RUNNING 1
@@ -91,7 +123,7 @@
 // ----------- Power -----------
 #define START_STOP_DELAY_MS 300000 // 5 Minuten Wartezeit
 #define CPU_FREQUENCY 80 // CPU Frequenz im Sleep-Modus
-#define VOLTAGE_CALCULATION_FAKTOR 4.79   // 4.7 Spannungsteiler // 4.84 aus Tabelle errechnet
+#define VOLTAGE_CALCULATION_FACTOR 4.79   // 4.7 Spannungsteiler // 4.84 aus Tabelle errechnet
 #define VOLTAGE_CHANGE_THRESHOLD 0.2 // z. B. 0.2 V Unterschied
 
 // --- ESP-NOW Sicherheit ---
@@ -140,6 +172,17 @@ unsigned long last_car_running_time = 0;
 int car_status = 0;
 unsigned long sleep_trigger_time  = 0;
 unsigned long last_battery_send_time = 0;
+unsigned long last_supported_pid_refresh_time = 0;
+unsigned long last_dtc_query_time = 0;
+unsigned long last_simulation_send_time = 0;
+uint32_t telemetry_sequence = 0;
+uint32_t can_frame_count = 0;
+size_t simulation_sample_index = 0;
+bool can_bus_active = false;
+bool supported_pids_initialized = false;
+uint32_t supported_pids_01_20 = 0;
+uint32_t supported_pids_21_40 = 0;
+uint32_t supported_pids_41_60 = 0;
 float last_fuel_rate = 0.0;    // L/h
 float last_speed = 0.0;        // km/h
 float consumption_sum = 0.0;   // Summe für Mittelwert
@@ -150,10 +193,17 @@ int consumption_count = 0;     // Anzahl Messungen
 // region ========================== OBD2-Konfiguration ==========================
 // Moegliche Abfragen siehe PIDs.h
 const byte obd_requested_pids[] = {
-  //ENGINE_RPM
+  ENGINE_RPM,
+  ENGINE_LOAD,
   ENGINE_COOLANT_TEMP,
   VEHICLE_SPEED,
+  INTAKE_AIR_TEMP,
+  MAF_FLOW_RATE,
+  THROTTLE_POSITION,
+  FUEL_TANK_LEVEL_INPUT,
+  RUN_TIME_SINCE_ENGINE_START,
   CONTROL_MODULE_VOLTAGE,
+  AMBIENT_AIR_TEMP,
   ENGINE_FUEL_RATE,
   ENGINE_OIL_TEMP
 };
@@ -161,6 +211,20 @@ const byte obd_pid_count = sizeof(obd_requested_pids) / sizeof(obd_requested_pid
 const unsigned long OBD_INTERVAL_MS = 2000;
 
 // End region ========================== OBD2-Konfiguration ==========================
+
+// region ========================== Funktionsprototypen ==========================
+int getMeshID();
+bool initCAN();
+bool sendOBDRequest(byte mode, byte pid);
+bool receiveOBDResponse(byte mode, byte pid, byte* outData, byte& outLen);
+void sendTelemetry(const char* type, const char* key, const char* name, const char* value, const char* unit, const char* status);
+void sendStatusFrame(const char* key, const char* value, const char* status);
+void sendOBDData(byte pid, const char* name, const char* value, const char* unit, const char* status);
+void refreshSupportedPIDs();
+bool isPIDSupported(byte pid);
+void queryAndSendDTCs();
+void sendSimulationTelemetry();
+// End region ========================== Funktionsprototypen ==========================
 
 // region ================ CRC ================
 uint16_t crc16(const uint8_t* data, size_t length) {
@@ -232,7 +296,7 @@ int getMeshID() {
 
 // region ================================== Setup ==================================
 void setup() {
-#ifdef DEBUG_FLAG
+#if DEBUG_FLAG
   Serial.begin(BUDRATE);
   debugln(BUDRATE);
 #endif
@@ -249,9 +313,9 @@ void setup() {
   debugln("https://gitlab.com/MrDIYca/canabus");
   debugln("------------------------");
 
-  last_can_msg_timestamp = millis() - CAN_IDLE_TIMEOUT + 5;
+  last_can_msg_timestamp = millis() - CAN_IDLE_TIMEOUT_MS + 5;
 
-  if (!initESPNow() || (!initCAN())) {
+  if (!initESPNow() || (!ENABLE_TELEMETRY_SIMULATION && !initCAN())) {
     debugln(" SYSTEM......... FAIL");
     debugln(" SYSTEM......... FAIL");
     debugln(" ... restarting");
@@ -259,6 +323,8 @@ void setup() {
     ESP.restart();
   }
 
+  sendTelemetry("STATUS", "FW", "Firmware", FIRMWARE_VERSION, "", "OK");
+  sendTelemetry("STATUS", "PROTO", "Protocol", "2", "", "OK");
   digitalWrite(SHIELD_LED_PIN, HIGH);
 }
 // End region ================================== Setup ==================================
@@ -304,7 +370,8 @@ if (TWAI_OPERATION_MODE == TWAI_MODE_NORMAL) {
     debugln(" CAN....Alerts.....FAIL");
     return false;
   }
-  debugln(" CAN.................OK");
+    debugln(" CAN.................OK");
+  can_bus_active = true;
   return true;
 }
 // End region ================================== initCAN ==================================
@@ -322,6 +389,17 @@ static void handleCANMessage(twai_message_t& message) {
   can_frame.crc = crc16((uint8_t*)&can_frame, sizeof(esp_now_frame_t) - 2);
 
   esp_now_send(peerAddress, (uint8_t*)&can_frame, sizeof(can_frame));
+  can_bus_active = true;
+  can_frame_count++;
+
+  // Zusaetzlich zum binaeren CAN-Frame senden wir eine textbasierte Kurzfassung.
+  // Das Display kann diese ohne Kenntnis der Rohframe-Struktur darstellen.
+  CANDecoder::DecodedFrame decoded = CANDecoder::decode(message);
+  sendTelemetry("CAN", "RAW", "LastCAN", decoded.raw, "", "OK");
+  sendTelemetry("CAN", "HINT", "CANHint", decoded.hint, "", "OK");
+  char countValue[16];
+  snprintf(countValue, sizeof(countValue), "%lu", static_cast<unsigned long>(can_frame_count));
+  sendTelemetry("CAN", "COUNT", "CANCount", countValue, "frames", "OK");
 
   debug("← CAN ID: 0x");
   debug(message.identifier, HEX);
@@ -363,7 +441,7 @@ bool sendOBDRequest(byte mode, byte pid) {
     debug(request.data[i], HEX);
   }
 
-  esp_err_t result = twai_transmit(&request, pdMS_TO_TICKS(10));
+  esp_err_t result = twai_transmit(&request, pdMS_TO_TICKS(OBD_TX_TIMEOUT_MS));
 
   if (result == ESP_OK) {
     debugln(" [OK]");
@@ -382,10 +460,26 @@ bool sendOBDRequest(byte mode, byte pid) {
 }
 // End region ================= OBD2 Anfrage senden =================
 
+// region ================= DTC Anfrage senden =================
+bool sendDTCRequest() {
+  twai_message_t request = {};
+  request.identifier = 0x7DF;
+  request.extd = 0;
+  request.rtr = 0;
+  request.data_length_code = 8;
+  request.data[0] = 0x01;      // Ein Datenbyte: Mode 03
+  request.data[1] = read_DTCs;
+  for (int i = 2; i < 8; i++) request.data[i] = 0x55;
+
+  esp_err_t result = twai_transmit(&request, pdMS_TO_TICKS(OBD_TX_TIMEOUT_MS));
+  return result == ESP_OK;
+}
+// End region ================= DTC Anfrage senden =================
+
 // region ================= OBD2 Antwort empfangen =================
 bool receiveOBDResponse(byte mode, byte pid, byte* outData, byte& outLen) {
   unsigned long start = millis();
-  while (millis() - start < 200) {
+  while (millis() - start < OBD_RESPONSE_TIMEOUT_MS) {
     twai_message_t response;
     if (twai_receive(&response, pdMS_TO_TICKS(10)) == ESP_OK) {
       
@@ -400,9 +494,13 @@ bool receiveOBDResponse(byte mode, byte pid, byte* outData, byte& outLen) {
       debugln("");
 
 
-      if (response.identifier >= 0x7E8 && response.identifier <= 0x7EF) {
+      if (response.identifier >= 0x7E8 && response.identifier <= 0x7EF &&
+          response.data_length_code >= 3 && response.data_length_code <= 8) {
+        last_can_msg_timestamp = millis();
+        can_bus_active = true;
         if (response.data[1] == (mode | 0x40) && response.data[2] == pid) {
           outLen = response.data_length_code - 3;
+          if (outLen > 5) outLen = 5;
           memcpy(outData, &response.data[3], outLen);
 
           debug(" OBD RESP: ID=0x");
@@ -424,7 +522,180 @@ bool receiveOBDResponse(byte mode, byte pid, byte* outData, byte& outLen) {
 }
 // End region ================= OBD2 Antwort empfangen =================
 
-// reginon ================ calcConsumption ================
+bool receiveDTCResponse(byte* outData, byte& outLen) {
+  unsigned long start = millis();
+  while (millis() - start < OBD_RESPONSE_TIMEOUT_MS) {
+    twai_message_t response;
+    if (twai_receive(&response, pdMS_TO_TICKS(10)) == ESP_OK) {
+      if (response.identifier >= 0x7E8 && response.identifier <= 0x7EF &&
+          response.data_length_code >= 3 && response.data_length_code <= 8 &&
+          response.data[1] == (read_DTCs | 0x40)) {
+        last_can_msg_timestamp = millis();
+        can_bus_active = true;
+
+        outLen = response.data_length_code - 2;
+        if (outLen > 6) outLen = 6;
+        memcpy(outData, &response.data[2], outLen);
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+// region ================= Supported PIDs =================
+uint32_t bytesToMask(const byte* data, byte length) {
+  if (length < 4) return 0;
+  return (static_cast<uint32_t>(data[0]) << 24) |
+         (static_cast<uint32_t>(data[1]) << 16) |
+         (static_cast<uint32_t>(data[2]) << 8) |
+         static_cast<uint32_t>(data[3]);
+}
+
+bool querySupportedPidRange(byte rangePid, uint32_t& targetMask) {
+  byte responseData[8];
+  byte responseLen = 0;
+
+  if (!sendOBDRequest(read_LiveData, rangePid)) return false;
+  if (!receiveOBDResponse(read_LiveData, rangePid, responseData, responseLen)) return false;
+
+  targetMask = bytesToMask(responseData, responseLen);
+  return targetMask != 0;
+}
+
+bool isPIDSupported(byte pid) {
+  if (!supported_pids_initialized) return true;
+
+  byte rangeBase = 0x00;
+  uint32_t mask = supported_pids_01_20;
+  if (pid >= 0x21 && pid <= 0x40) {
+    rangeBase = 0x20;
+    mask = supported_pids_21_40;
+  } else if (pid >= 0x41 && pid <= 0x60) {
+    rangeBase = 0x40;
+    mask = supported_pids_41_60;
+  } else if (pid < 0x01 || pid > 0x20) {
+    return false;
+  }
+
+  const byte offset = pid - rangeBase;
+  if (offset == 0 || offset > 32) return false;
+  return (mask & (1UL << (32 - offset))) != 0;
+}
+
+void refreshSupportedPIDs() {
+  bool ok = querySupportedPidRange(SUPPORTED_PIDS_1_20, supported_pids_01_20);
+
+  if (ok && (supported_pids_01_20 & 0x00000001UL)) {
+    ok = querySupportedPidRange(SUPPORTED_PIDS_21_40, supported_pids_21_40);
+  }
+
+  if (ok && (supported_pids_21_40 & 0x00000001UL)) {
+    ok = querySupportedPidRange(SUPPORTED_PIDS_41_60, supported_pids_41_60);
+  }
+
+  supported_pids_initialized = ok;
+  sendStatusFrame("PID_SUPPORT", ok ? "READY" : "UNKNOWN", ok ? "OK" : "WARN");
+}
+// End region ================= Supported PIDs =================
+
+// region ================= DTCs lesen =================
+char dtcTypeChar(byte highBits) {
+  switch (highBits & 0x03) {
+    case 0: return 'P';
+    case 1: return 'C';
+    case 2: return 'B';
+    default: return 'U';
+  }
+}
+
+void appendDTC(char* buffer, size_t bufferSize, byte a, byte b) {
+  if (a == 0 && b == 0) return;
+
+  char code[8];
+  snprintf(code, sizeof(code), "%c%01X%03X",
+           dtcTypeChar(a >> 6),
+           (a >> 4) & 0x03,
+           ((a & 0x0F) << 8) | b);
+
+  const size_t used = strlen(buffer);
+  if (used >= bufferSize - 1) return;
+
+  snprintf(buffer + used, bufferSize - used, "%s%s", used > 0 ? " " : "", code);
+}
+
+void queryAndSendDTCs() {
+  byte responseData[8];
+  byte responseLen = 0;
+
+  if (!sendDTCRequest()) {
+    sendTelemetry("DTC", "ACTIVE", "DTC", "N/A", "", "SEND_FAIL");
+    return;
+  }
+
+  if (!receiveDTCResponse(responseData, responseLen)) {
+    sendTelemetry("DTC", "ACTIVE", "DTC", "N/A", "", "TIMEOUT");
+    return;
+  }
+
+  char dtcList[64] = {0};
+  for (byte i = 0; i + 1 < responseLen; i += 2) {
+    appendDTC(dtcList, sizeof(dtcList), responseData[i], responseData[i + 1]);
+  }
+
+  if (dtcList[0] == '\0') {
+    sendTelemetry("DTC", "ACTIVE", "DTC", "Keine", "", "OK");
+  } else {
+    sendTelemetry("DTC", "ACTIVE", "DTC", dtcList, "", "WARN");
+  }
+}
+// End region ================= DTCs lesen =================
+
+// region ================ Telemetrie senden ================
+void sendTelemetry(const char* type,
+                   const char* key,
+                   const char* name,
+                   const char* value,
+                   const char* unit,
+                   const char* status) {
+  TelemetryProtocol::buildPayload(text_frame.payload, sizeof(text_frame.payload),
+                                  type, key, name, value, unit, status,
+                                  ++telemetry_sequence);
+  text_frame.crc = TelemetryProtocol::crc16((uint8_t*)&text_frame, sizeof(text_frame) - 2);
+  esp_now_send(peerAddress, (uint8_t*)&text_frame, sizeof(text_frame));
+}
+
+void sendStatusFrame(const char* key, const char* value, const char* status) {
+  sendTelemetry("STATUS", key, key, value, "", status);
+}
+
+void sendSimulationTelemetry() {
+  if (millis() - last_simulation_send_time < SIMULATION_SEND_INTERVAL_MS) return;
+  last_simulation_send_time = millis();
+
+  const SimulationData::Sample& sample =
+      SimulationData::Samples[simulation_sample_index % SimulationData::SampleCount];
+
+  char value[16];
+  const float simulatedValue = SimulationData::valueForSample(sample, millis(), simulation_sample_index);
+  snprintf(value, sizeof(value), sample.decimals == 0 ? "%.0f" : "%.1f", simulatedValue);
+  sendTelemetry(sample.type, sample.key, sample.name, value, sample.unit, "OK");
+
+  simulation_sample_index++;
+
+  // Status-, CAN- und DTC-Pakete werden zwischen die Messwerte gemischt, damit
+  // alle Display-Seiten ohne Fahrzeug und ohne CAN-Transceiver getestet werden koennen.
+  if (simulation_sample_index % SimulationData::SampleCount == 0) {
+    sendStatusFrame("CAN", "SIMULATED", "OK");
+    sendTelemetry("CAN", "RAW", "LastCAN", "0x7E8 DLC8 04 41 0C 1A F8 55 55 55", "", "OK");
+    sendTelemetry("CAN", "HINT", "CANHint", "Simulierte OBD Antwort RPM", "", "OK");
+    sendTelemetry("CAN", "COUNT", "CANCount", "128", "frames", "OK");
+    sendTelemetry("DTC", "ACTIVE", "DTC", "P0133 P0420", "", "WARN");
+  }
+}
+// end region ================ Telemetrie senden ================
+
+// region ================ calcConsumption ================
 void calcConsumption(byte pid, float value) {
     if (pid == VEHICLE_SPEED) last_speed = value;
     if (pid == ENGINE_FUEL_RATE) last_fuel_rate = value;
@@ -442,23 +713,21 @@ void calcConsumption(byte pid, float value) {
     if (consumption_count >= 10) {
         float avg_consumption = consumption_sum / consumption_count;
 
-        snprintf(text_frame.payload, sizeof(text_frame.payload),
-                 "FUEL_CONS,AVG,%.2f,L100", avg_consumption);
-        text_frame.crc = crc16((uint8_t*)&text_frame, sizeof(text_frame) - 2);
-        esp_now_send(peerAddress, (uint8_t*)&text_frame, sizeof(text_frame));
+        char avgConsumption[16];
+        snprintf(avgConsumption, sizeof(avgConsumption), "%.2f", avg_consumption);
+        sendTelemetry("FUEL", "AVG", "AverageConsumption", avgConsumption, "L/100km", "OK");
 
         consumption_sum = 0;
         consumption_count = 0;
     }
 }
-// end reginon ================ calcConsumption ================
+// end region ================ calcConsumption ================
 
 // region ================= OBD2 Anfrage senden und Antwort verarbeiten =================
-void sendOBDData(byte pid, const char* name, const char* value) {
-  snprintf(text_frame.payload, sizeof(text_frame.payload),
-           "%02X,%s,%s", pid, name, value);
-  text_frame.crc = crc16((uint8_t*)&text_frame, sizeof(text_frame) - 2);
-  esp_now_send(peerAddress, (uint8_t*)&text_frame, sizeof(text_frame));
+void sendOBDData(byte pid, const char* name, const char* value, const char* unit, const char* status) {
+  char pidHex[4];
+  snprintf(pidHex, sizeof(pidHex), "%02X", pid);
+  sendTelemetry("OBD", pidHex, name, value, unit, status);
 }
 // --- Die Hauptfunktion ---
 void requestAndSendOBDPID(byte pid) {
@@ -470,7 +739,7 @@ void requestAndSendOBDPID(byte pid) {
     debug(getPIDName(pid));
     debugln("] SEND FAIL");
 
-    sendOBDData(pid, "ERROR", "N/A");
+    sendOBDData(pid, getPIDName(pid), "N/A", "", "SEND_FAIL");
     return;
   }
   // ------------ Antwort empfangen ------------
@@ -485,11 +754,15 @@ void requestAndSendOBDPID(byte pid) {
     for (byte i = 0; i < responseLen; i++) {
       sprintf(&rawHex[i * 3], "%02X ", responseData[i]);
     }
-    sendOBDData(pid, getPIDName(pid), rawHex);
+    sendOBDData(pid, getPIDName(pid), rawHex, "raw", "OK");
 
 #else
     // Umrechnen in physikalische Werte
     PIDResult result = convertPID(pid, responseData, responseLen);
+    if (strcmp(result.unit, "INVALID") == 0) {
+      sendOBDData(pid, getPIDName(pid), "N/A", "", "DATA_ERROR");
+      return;
+    }
 
     debug("← OBD PID: 0x");
     debug(pid, HEX);
@@ -506,11 +779,9 @@ void requestAndSendOBDPID(byte pid) {
     }
 
     // Nur PIDs senden, die nicht für Verbrauchsberechnung reserviert sind
-    if (pid != VEHICLE_SPEED && pid != ENGINE_FUEL_RATE) {
-      char valueStr[16];
-      snprintf(valueStr, sizeof(valueStr), "%.2f %s", result.value, result.unit);
-      sendOBDData(pid, getPIDName(pid), valueStr);
-    }
+    char valueStr[16];
+    snprintf(valueStr, sizeof(valueStr), "%.2f", result.value);
+    sendOBDData(pid, getPIDName(pid), valueStr, result.unit, "OK");
 #endif
 
   } else {
@@ -520,7 +791,7 @@ void requestAndSendOBDPID(byte pid) {
     debug(getPIDName(pid));
     debugln("] TIMEOUT");
 
-    sendOBDData(pid, "ERROR", "N/A");
+    sendOBDData(pid, getPIDName(pid), "N/A", "", "TIMEOUT");
   }
 }
   // -------------------------------------------
@@ -541,7 +812,7 @@ void handleSleep() {
   if (car_status == CAR_IS_OFF &&
       (currentMillis - last_car_running_time > START_STOP_DELAY_MS) &&
       (currentMillis - last_obd_request_time >= OBD_INTERVAL_MS)) {
-      //(currentMillis - last_can_msg_timestamp > CAN_IDLE_TIMEOUT)) {
+      //(currentMillis - last_can_msg_timestamp > CAN_IDLE_TIMEOUT_MS)) {
     esp_deep_sleep();
   }
 }
@@ -600,7 +871,7 @@ VoltageMeasurement get_vin_voltage() {
 
   VoltageMeasurement result;
   result.adc_raw = avg;
-  result.voltage = (avg / 4095.0) * 3.3 * VOLTAGE_CALCULATION_FAKTOR;
+  result.voltage = (avg / 4095.0) * 3.3 * VOLTAGE_CALCULATION_FACTOR;
   return result;
 }
 // ------------ Fahrzeugstatus anhand Batteriespannung bestimmen ------------
@@ -641,15 +912,14 @@ void sendBatteryVoltage() {
 
   // Optional: Warnung bei Grenzwerten
   if (voltage < 11.5 || voltage > 14.8) {
-    snprintf(text_frame.payload, sizeof(text_frame.payload),
-             "BATTERY,ALERT,%.2f,V", voltage);
+    char voltageStr[16];
+    snprintf(voltageStr, sizeof(voltageStr), "%.2f", voltage);
+    sendTelemetry("BATTERY", "VOLTAGE", "BatteryVoltage", voltageStr, "V", "ALERT");
   } else {
-    snprintf(text_frame.payload, sizeof(text_frame.payload),
-             "BATTERY,VOLTAGE,%.2f,V", voltage);
+    char voltageStr[16];
+    snprintf(voltageStr, sizeof(voltageStr), "%.2f", voltage);
+    sendTelemetry("BATTERY", "VOLTAGE", "BatteryVoltage", voltageStr, "V", "OK");
   }
-
-  text_frame.crc = crc16((uint8_t*)&text_frame, sizeof(text_frame) - 2);
-  esp_now_send(peerAddress, (uint8_t*)&text_frame, sizeof(text_frame));
 }
 
 // End region ======================== Power ===============================
@@ -728,7 +998,7 @@ void printTWAIStatus() {
 #endif
 // End region ================ TWAI Status ================
 
-// reginon ================ LED-Test ================
+// region ================ LED-Test ================
 void ledtest() {
   digitalWrite(SHIELD_LED_PIN, LOW);
   digitalWrite(SHIELD_LED_PIN2, LOW);
@@ -741,11 +1011,17 @@ void blinkLED(uint8_t pin) {
   delay(50);
   digitalWrite(pin, LOW);
 }
-// end reginon ================ LED-Test ================
+// end region ================ LED-Test ================
 
 // region ================================== loop ==================================
 void loop() {
   currentMillis = millis();
+
+  if (ENABLE_TELEMETRY_SIMULATION) {
+    sendSimulationTelemetry();
+    return;
+  }
+
   uint32_t alerts_triggered;
   twai_read_alerts(&alerts_triggered, pdMS_TO_TICKS(POLLING_RATE_MS));
 
@@ -770,12 +1046,14 @@ void loop() {
       debugln("Alert: TWAI controller has become error passive.");
       ledShouldBeOn = true;
       debugln(" CAN MSG..........ERROR");
+      sendStatusFrame("CAN", "ERROR_PASSIVE", "WARN");
   }
   if (alerts_triggered & TWAI_ALERT_BUS_ERROR) {
       debugln("Alert: A (Bit, Stuff, CRC, Form, ACK) error has occurred on the bus.");
       //Serial.printf("Bus error count: %d\n", twaistatus.bus_error_count);
       ledShouldBeOn = true;
       debugln(" CAN MSG......BUS ERROR");
+      sendStatusFrame("CAN", "BUS_ERROR", "ERROR");
   }
   if (alerts_triggered & TWAI_ALERT_RX_QUEUE_FULL) {
       debugln("Alert: The RX queue is full causing a received frame to be lost.");
@@ -784,6 +1062,7 @@ void loop() {
       //Serial.printf("RX overrun %d\n", twaistatus.rx_overrun_count);
       ledShouldBeOn = true;
       debugln(" CAN MSG.........Q FULL");
+      sendStatusFrame("CAN", "RX_QUEUE_FULL", "ERROR");
   }
   //---------------------------------------
 
@@ -802,9 +1081,32 @@ void loop() {
 
   //------------- OBD2 Daten regelmäßig abfragen -------------
   if (ENABLE_OBD2 && currentMillis - last_obd_request_time >= OBD_INTERVAL_MS) {
+    can_bus_active = (currentMillis - last_can_msg_timestamp) <= CAN_IDLE_TIMEOUT_MS;
+    sendStatusFrame("CAN", can_bus_active ? "ACTIVE" : "IDLE", can_bus_active ? "OK" : "TIMEOUT");
+
+    if (!supported_pids_initialized ||
+        currentMillis - last_supported_pid_refresh_time >= SUPPORTED_PID_REFRESH_INTERVAL_MS) {
+      refreshSupportedPIDs();
+      last_supported_pid_refresh_time = currentMillis;
+    }
+
+    static bool unsupported_pid_reported[obd_pid_count] = {false};
     for (byte i = 0; i < obd_pid_count; i++) {
+      if (!isPIDSupported(obd_requested_pids[i])) {
+        if (!unsupported_pid_reported[i]) {
+          sendOBDData(obd_requested_pids[i], getPIDName(obd_requested_pids[i]), "N/A", "", "UNSUPPORTED");
+          unsupported_pid_reported[i] = true;
+        }
+        continue;
+      }
       requestAndSendOBDPID(obd_requested_pids[i]);
     }
+
+    if (currentMillis - last_dtc_query_time >= DTC_QUERY_INTERVAL_MS) {
+      queryAndSendDTCs();
+      last_dtc_query_time = currentMillis;
+    }
+
     last_obd_request_time = currentMillis;
   }
   //----------------------------------------------------------
@@ -812,7 +1114,7 @@ void loop() {
   //--------------TWAI Status-----------
   // Optional zur Fehlersuche
   #if TWAI_DEBUG_FLAG
-    printTWAIStatus(); // Aktievieren / Deaktivieren  #define TWAI_DEBUG_FLAG 0
+    printTWAIStatus(); // Aktivieren / Deaktivieren: #define TWAI_DEBUG_FLAG 0
   #endif
   //-------------------------------------------------------
 
@@ -822,7 +1124,7 @@ void loop() {
   //-------------------------------------------------------
 
   //------------- Batteriespannung senden -----------
-  if (millis() - last_battery_send_time > 3000) {  //5000
+  if (millis() - last_battery_send_time > BATTERY_SEND_INTERVAL_MS) {
   sendBatteryVoltage();
   last_battery_send_time = millis();
   }

--- a/src/CANDecoder.cpp
+++ b/src/CANDecoder.cpp
@@ -1,0 +1,31 @@
+#include "CANDecoder.h"
+
+namespace CANDecoder {
+
+DecodedFrame decode(const twai_message_t& message) {
+    DecodedFrame decoded;
+
+    size_t offset = snprintf(decoded.raw, sizeof(decoded.raw),
+                             "0x%03lX DLC%u",
+                             static_cast<unsigned long>(message.identifier),
+                             static_cast<unsigned int>(message.data_length_code));
+
+    for (uint8_t i = 0; i < message.data_length_code && offset < sizeof(decoded.raw); ++i) {
+        offset += snprintf(decoded.raw + offset, sizeof(decoded.raw) - offset,
+                           " %02X", message.data[i]);
+    }
+
+    if (message.identifier >= 0x7E8 && message.identifier <= 0x7EF &&
+        message.data_length_code >= 3 && message.data[1] >= 0x40) {
+        snprintf(decoded.hint, sizeof(decoded.hint), "OBD Antwort Mode %02X PID %02X",
+                 message.data[1] - 0x40, message.data[2]);
+    } else if (message.identifier == 0x7DF) {
+        snprintf(decoded.hint, sizeof(decoded.hint), "OBD Anfrage Broadcast");
+    } else {
+        snprintf(decoded.hint, sizeof(decoded.hint), "CAN Rohdaten");
+    }
+
+    return decoded;
+}
+
+} // namespace CANDecoder

--- a/src/CANHandler.cpp
+++ b/src/CANHandler.cpp
@@ -1,6 +1,7 @@
 #include "CANHandler.h"
 #include "Config.h"
 #include "Utils.h"
+#include "CANDecoder.h"
 
 bool CANHandler::init() {
     Logger::debug(" CAN...............INIT");
@@ -61,8 +62,13 @@ void CANHandler::processIncoming() {
 }
 
 void CANHandler::handleMessage(twai_message_t& message) {
-    // Sende CAN Frame via Utils
+    // Binaeres Rohframe bleibt fuer externe Tools erhalten.
     Utils::sendCanFrame(message.identifier, message.data, message.data_length_code);
+
+    // Zusaetzlich eine lesbare Textauswertung fuer die Display-CAN-Seite senden.
+    CANDecoder::DecodedFrame decoded = CANDecoder::decode(message);
+    Utils::sendTelemetry("CAN", "RAW", "LastCAN", decoded.raw, "", "OK");
+    Utils::sendTelemetry("CAN", "HINT", "CANHint", decoded.hint, "", "OK");
 
     // Debug-Ausgabe
     Logger::canFrame(message);

--- a/src/OBDHandler.cpp
+++ b/src/OBDHandler.cpp
@@ -49,7 +49,9 @@ void OBD2Handler::calcConsumption(uint8_t pid, float value) {
 
     if (Config::consumptionCount >= 10) {
         float avg = Config::consumptionSum / Config::consumptionCount;
-        Utils::sendOBDValue(0xFE, "FUEL_CONS", avg, "L100");
+        char avgText[16];
+        snprintf(avgText, sizeof(avgText), "%.2f", avg);
+        Utils::sendTelemetry("FUEL", "AVG", "AverageConsumption", avgText, "L/100km", "OK");
 
         Config::consumptionSum = 0.0f;
         Config::consumptionCount = 0;
@@ -75,9 +77,7 @@ void OBD2Handler::requestAndSendPID(uint8_t pid) {
                 calcConsumption(pid, result.value);
             }
 
-            if (pid != VEHICLE_SPEED && pid != ENGINE_FUEL_RATE) {
-                Utils::sendOBDValue(pid, getPIDName(pid), result.value, result.unit);
-            }
+            Utils::sendOBDValue(pid, getPIDName(pid), result.value, result.unit);
         }
     } else {
         Utils::sendOBDError(pid, getPIDName(pid));

--- a/src/PID_Converter.cpp
+++ b/src/PID_Converter.cpp
@@ -60,31 +60,46 @@ namespace {
         return {((d[0] * 256.0f) + d[1]) / 20.0f, "L/h"};
     }
 
+    PIDResult convertRUN_TIME_SINCE_ENGINE_START(const byte* d) {
+        return {((d[0] * 256.0f) + d[1]), "s"};
+    }
+
+    PIDResult convertAMBIENT_AIR_TEMP(const byte* d) {
+        return {d[0] - 40.0f, "°C"};
+    }
+
     PIDResult unknownPID() {
         return {-1.0f, "N/A"};
+    }
+
+    PIDResult invalidLength() {
+        return {-1.0f, "INVALID"};
     }
 
     typedef PIDResult (*ConverterFunc)(const byte*);
     struct PIDConverterEntry {
         byte pid;
         ConverterFunc func;
+        byte minLength;
     };
 
     const PIDConverterEntry converterTable[] = {
-        {ENGINE_LOAD, convertENGINE_LOAD},
-        {ENGINE_COOLANT_TEMP, convertENGINE_COOLANT_TEMP},
-        {FUEL_PRESSURE, convertFUEL_PRESSURE},
-        {INTAKE_MANIFOLD_ABS_PRESSURE, convertINTAKE_MANIFOLD_ABS_PRESSURE},
-        {ENGINE_RPM, convertENGINE_RPM},
-        {VEHICLE_SPEED, convertVEHICLE_SPEED},
-        {TIMING_ADVANCE, convertTIMING_ADVANCE},
-        {INTAKE_AIR_TEMP, convertINTAKE_AIR_TEMP},
-        {MAF_FLOW_RATE, convertMAF_FLOW_RATE},
-        {THROTTLE_POSITION, convertTHROTTLE_POSITION},
-        {FUEL_TANK_LEVEL_INPUT, convertFUEL_TANK_LEVEL_INPUT},
-        {CONTROL_MODULE_VOLTAGE, convertCONTROL_MODULE_VOLTAGE},
-        {ENGINE_OIL_TEMP, convertENGINE_OIL_TEMP},
-        {ENGINE_FUEL_RATE, convertENGINE_FUEL_RATE},
+        {ENGINE_LOAD, convertENGINE_LOAD, 1},
+        {ENGINE_COOLANT_TEMP, convertENGINE_COOLANT_TEMP, 1},
+        {FUEL_PRESSURE, convertFUEL_PRESSURE, 1},
+        {INTAKE_MANIFOLD_ABS_PRESSURE, convertINTAKE_MANIFOLD_ABS_PRESSURE, 1},
+        {ENGINE_RPM, convertENGINE_RPM, 2},
+        {VEHICLE_SPEED, convertVEHICLE_SPEED, 1},
+        {TIMING_ADVANCE, convertTIMING_ADVANCE, 1},
+        {INTAKE_AIR_TEMP, convertINTAKE_AIR_TEMP, 1},
+        {MAF_FLOW_RATE, convertMAF_FLOW_RATE, 2},
+        {THROTTLE_POSITION, convertTHROTTLE_POSITION, 1},
+        {RUN_TIME_SINCE_ENGINE_START, convertRUN_TIME_SINCE_ENGINE_START, 2},
+        {FUEL_TANK_LEVEL_INPUT, convertFUEL_TANK_LEVEL_INPUT, 1},
+        {CONTROL_MODULE_VOLTAGE, convertCONTROL_MODULE_VOLTAGE, 2},
+        {AMBIENT_AIR_TEMP, convertAMBIENT_AIR_TEMP, 1},
+        {ENGINE_OIL_TEMP, convertENGINE_OIL_TEMP, 1},
+        {ENGINE_FUEL_RATE, convertENGINE_FUEL_RATE, 2},
     };
 
     const size_t converterTableSize = sizeof(converterTable) / sizeof(PIDConverterEntry);
@@ -95,6 +110,7 @@ namespace {
 PIDResult convertPID(byte pid, const byte* data, byte length) {
     for (size_t i = 0; i < converterTableSize; ++i) {
         if (converterTable[i].pid == pid) {
+            if (length < converterTable[i].minLength) return invalidLength();
             return converterTable[i].func(data);
         }
     }
@@ -123,8 +139,10 @@ const char* getPIDName(byte pid) {
         case INTAKE_AIR_TEMP:                  return "IntakeTemp";
         case MAF_FLOW_RATE:                    return "MAF";
         case THROTTLE_POSITION:                return "Throttle";
+        case RUN_TIME_SINCE_ENGINE_START:      return "RunTime";
         case FUEL_TANK_LEVEL_INPUT:            return "FuelLevel";
         case CONTROL_MODULE_VOLTAGE:           return "ControlVoltage";
+        case AMBIENT_AIR_TEMP:                 return "AmbientTemp";
         case ENGINE_OIL_TEMP:                  return "OilTemp";
         case ENGINE_FUEL_RATE:                 return "FuelRate";
         default:                               return "Unknown";


### PR DESCRIPTION
## Summary

- Adds a shared ESP-NOW telemetry protocol and CRC helpers.
- Adds shared simulation data for sender/display communication testing.
- Adds CAN raw-frame decoding and a dedicated CAN display page.
- Expands the display to dashboard, engine, consumption, additional values, CAN, diagnostics, and DTC pages.
- Adds OBD supported-PID filtering, DTC querying, additional PIDs, timeout/status handling, and better sender/display synchronization.
- Updates existing `.cpp`/`.h` modules (`Utils`, `CANHandler`, `OBDHandler`, `Config`) to use the same telemetry format and preserve Speed/FuelRate transmissions.

## Validation

- Static checks of changed file references and old protocol remnants.
- Local commit created and pushed successfully.
- Build not run: PlatformIO/Arduino CLI are not installed in this environment.

## Hardware follow-up

- Verify ESP-NOW MAC pairing and encryption on both devices.
- Test sender simulation (`ENABLE_TELEMETRY_SIMULATION`) before vehicle testing.
- Test live CAN/OBD behavior on hardware, especially DTC handling and supported-PID filtering.
- Confirm LilyGo button GPIO for page switching.